### PR TITLE
Add payment plans list in the category creation and edition page

### DIFF
--- a/mobbex/classes/MobbexHelper.php
+++ b/mobbex/classes/MobbexHelper.php
@@ -322,6 +322,9 @@ class MobbexHelper
         }
     }
 
+    /**
+     * Return the plans that were not selected in the product and category page
+     */
     public static function getInstallments($products)
     {
 
@@ -335,14 +338,21 @@ class MobbexHelper
         );
 
         foreach ($products as $product) {
-
+            $categories = Product::getProductCategoriesFull($product['id_product']);
             foreach ($ahora as $key => $value) {
 
                 if (MobbexCustomFields::getCustomField($product['id_product'], 'product', $key)['data'] === 'yes') {
                     $installments[] = '-' . $key;
                     unset($ahora[$key]);
+                }else{
+                    foreach($categories as $category){
+                        if (MobbexCustomFields::getCustomField($category['id_category'], 'category', $key)['data'] === 'yes') {
+                            $installments[] = '-' . $key;
+                            unset($ahora[$key]);
+                            break;
+                        }
+                    }
                 }
-
             }
 
         }

--- a/mobbex/mobbex.php
+++ b/mobbex/mobbex.php
@@ -94,11 +94,11 @@ class Mobbex extends PaymentModule
         $this->_createTable();
 
         if (MobbexHelper::getPsVersion() === MobbexHelper::PS_16) {
-            if (!parent::install() || !$this->registerHook('payment') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductButtons') || !$this->registerHook('displayCustomerAccountForm') || !$this->registerHook('actionCustomerAccountAdd') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate')) {
+            if (!parent::install() || !$this->registerHook('payment') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductButtons') || !$this->registerHook('displayCustomerAccountForm') || !$this->registerHook('actionCustomerAccountAdd') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate') || !$this->registerHook('displayBackOfficeCategory') || !$this->registerHook('categoryAddition') || !$this->registerHook('categoryUpdate')) { 
                 return false;
             }
         } else {
-            if (!parent::install() || !$this->registerHook('paymentOptions') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductAdditionalInfo') || !$this->registerHook('additionalCustomerFormFields') || !$this->registerHook('actionObjectCustomerUpdateAfter') || !$this->registerHook('actionObjectCustomerAddAfter') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate')) {
+            if (!parent::install() || !$this->registerHook('paymentOptions') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductAdditionalInfo') || !$this->registerHook('additionalCustomerFormFields') || !$this->registerHook('actionObjectCustomerUpdateAfter') || !$this->registerHook('actionObjectCustomerAddAfter') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate') || !$this->registerHook('displayBackOfficeCategory') || !$this->registerHook('categoryAddition') || !$this->registerHook('categoryUpdate')) {
                 return false;
             }
         }
@@ -932,5 +932,82 @@ class Mobbex extends PaymentModule
             }
             MobbexCustomFields::saveCustomField($params['id_product'], 'product', $key, $value);
         }
+    }
+
+    /**
+     * Create costumer hook for Prestashop 1.6 - 1.7
+     *
+     * Support for 1.6 and 1.7
+     *
+     * @return string
+     */
+    public function hookDisplayBackOfficeCategory($params)
+    {
+        //depending on the version $params['request'] can be empty 
+        if($params['request']){
+            $category_id = (int)$params['request']->get('categoryId');
+        }else{
+            $category_id = $params['id_category'] ? : Tools::getValue('id_category');
+        }
+        
+        
+        $ahora = array(
+            'ahora_3' => array(
+                'label' => 'Ahora 3',
+                'data' => MobbexCustomFields::getCustomField($category_id, 'category', 'ahora_3')['data'],
+            ),
+            'ahora_6' => array(
+                'label' => 'Ahora 6',
+                'data' => MobbexCustomFields::getCustomField($category_id, 'category', 'ahora_6')['data'],
+            ),
+            'ahora_12' => array(
+                'label' => 'Ahora 12',
+                'data' => MobbexCustomFields::getCustomField($category_id, 'category', 'ahora_12')['data'],
+            ),
+            'ahora_18' => array(
+                'label' => 'Ahora 18',
+                'data' => MobbexCustomFields::getCustomField($category_id, 'category', 'ahora_18')['data'],
+            ),
+        );
+        
+        $this->context->smarty->assign(
+            array(
+                'ahora' => $ahora,
+                'ps_version' => MobbexHelper::getPsVersion(),
+            )
+        );
+
+        return $this->display(__FILE__, 'views/templates/hooks/category_fields.tpl');
+        
+    }
+
+
+    /**
+     * Save the selected payment plans in the category page
+     */
+    public function hookCategoryAddition($params)
+    {
+        $ahora = array(
+            'ahora_3',
+            'ahora_6',
+            'ahora_12',
+            'ahora_18',
+        );
+
+        foreach ($ahora as $key) {
+            $value = 'no';
+            if (!empty($_POST[$key])) {
+                $value = 'yes';
+            }
+            MobbexCustomFields::saveCustomField($params['category']->id, 'category', $key, $value);
+        }
+    }
+ 
+    /**
+     * Save the selected payment plans in the category edit page
+     */
+    public function hookCategoryUpdate($params)
+    {
+        $this->hookCategoryAddition($params);
     }
 }

--- a/mobbex/views/templates/hooks/category_fields.tpl
+++ b/mobbex/views/templates/hooks/category_fields.tpl
@@ -1,0 +1,19 @@
+<div class="form-group">
+    <div class="row">
+      <div class="col-md-12">
+        <h3>{l s='Elija los planes que NO quiera que aparezcan durante la compra' mod='mobbex'}</h3>
+      </div>
+    </div>
+    {foreach item=item key=key from=$ahora}
+    <div class="row" style="margin-left: 15px;">
+      <div class="col-md-8 form-group">
+        <div class="checkbox">                          
+          <label style="font-size: 16px;padding-left: 10px;">
+            <input type="checkbox" id="{$key}" name="{$key}" {if !empty($item['data'] && $item['data'] == 'yes')}checked="checked"{/if}>
+            {$item['label']}
+          </label>
+        </div>
+      </div>
+    </div>
+    {/foreach}
+</div>


### PR DESCRIPTION
# Description

Add a checkbox list with payment plans in the category creation and edition page. The selected plans in the category will be added to the selected plans in product pages.


## Tasks


- [ ] Add checkbox list in category creation page
- [ ] Add checkbox list in category edition page
- [ ] Save the selected plans in custom mobbex field
- [ ] Send the selected plans to payment page 

# Tested

The plugin was tested in the following versions of Prestashop
- [x] 1.6
- [x] 1.7.6