### PR TITLE
Notify order  refund in the Order Page

### DIFF
--- a/mobbex/classes/MobbexHelper.php
+++ b/mobbex/classes/MobbexHelper.php
@@ -350,4 +350,36 @@ class MobbexHelper
         return $installments;
 
     }
+
+    /**
+    * Inform to Mobbex a total order refund 
+    *
+    * @return array
+    */
+    public static function porcessRefund($id_transaction)
+    {
+        $curl = curl_init();
+        curl_setopt_array($curl, array(
+            CURLOPT_URL => "https://api.mobbex.com/p/operations/".$id_transaction."/refund",
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING => "",
+            CURLOPT_MAXREDIRS => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST => "GET",
+            CURLOPT_HTTPHEADER => self::getHeaders(),
+        ));
+
+        $response = curl_exec($curl);
+        $err = curl_error($curl);
+        curl_close($curl);
+
+        if ($err) {
+            return d("CURL Error #:" . $err);
+        } else {
+            $res = json_decode($response, true);
+
+            return $res['result'];
+        }
+    }
 }

--- a/mobbex/mobbex.php
+++ b/mobbex/mobbex.php
@@ -94,11 +94,11 @@ class Mobbex extends PaymentModule
         $this->_createTable();
 
         if (MobbexHelper::getPsVersion() === MobbexHelper::PS_16) {
-            if (!parent::install() || !$this->registerHook('payment') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductButtons') || !$this->registerHook('displayCustomerAccountForm') || !$this->registerHook('actionCustomerAccountAdd') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate')) {
+            if (!parent::install() || !$this->registerHook('payment') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductButtons') || !$this->registerHook('displayCustomerAccountForm') || !$this->registerHook('actionCustomerAccountAdd') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate') || !$this->registerHook('actionOrderStatusPostUpdate')) {
                 return false;
             }
         } else {
-            if (!parent::install() || !$this->registerHook('paymentOptions') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductAdditionalInfo') || !$this->registerHook('additionalCustomerFormFields') || !$this->registerHook('actionObjectCustomerUpdateAfter') || !$this->registerHook('actionObjectCustomerAddAfter') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate')) {
+            if (!parent::install() || !$this->registerHook('paymentOptions') || !$this->registerHook('paymentReturn') || !$this->registerHook('displayProductAdditionalInfo') || !$this->registerHook('additionalCustomerFormFields') || !$this->registerHook('actionObjectCustomerUpdateAfter') || !$this->registerHook('actionObjectCustomerAddAfter') || !$this->registerHook('displayAdminProductsExtra') || !$this->registerHook('actionProductUpdate') || !$this->registerHook('actionOrderStatusPostUpdate')) {
                 return false;
             }
         }
@@ -862,6 +862,78 @@ class Mobbex extends PaymentModule
         );
 
         return $this->display(__FILE__, $template);
+    }
+
+
+    /**
+     * Is trigger when the state of an order is change, and works only if it is a mobbex transaction
+     * it first get the transaction_id from mobbex_transaction table, later the id is going to be use
+     * to call the API
+     * 
+     * Support for 1.6 Only
+     *
+     * @return string
+     */
+    public function hookActionOrderStatusPostUpdate($params)
+    {
+        $idRefunded = (int)Configuration::get('PS_OS_REFUND');//get id of refunded state
+        $order = Db::getInstance()->getRow(' SELECT * FROM '._DB_PREFIX_.'orders WHERE id_order = '.$params['id_order']);
+        if($params['newOrderStatus']->id == $idRefunded && $order['module'] == 'mobbex'){
+            $transactionData = Db::getInstance()->getRow(' SELECT data FROM '._DB_PREFIX_.'mobbex_transaction WHERE cart_id = '.$order['id_cart']);
+            $transaction_id = $this->processOrderData($transactionData['data']);
+            $curl = curl_init();
+            curl_setopt_array($curl, array(
+                CURLOPT_URL => "https://api.mobbex.com/p/operations/".$transaction_id."/refund",
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_ENCODING => "",
+                CURLOPT_MAXREDIRS => 10,
+                CURLOPT_TIMEOUT => 30,
+                CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+                CURLOPT_CUSTOMREQUEST => "GET",
+                CURLOPT_HTTPHEADER => $this->getHeaders(),
+            ));
+
+            $response = curl_exec($curl);
+            $err = curl_error($curl);
+            curl_close($curl);
+
+            if ($err) {
+                d("CURL Error #:" . $err);
+            } else {
+                $res = json_decode($response, true);
+    
+                return $res['result'];
+            }
+        }
+        return false;//not a mobbex transaction
+    }
+
+    /**
+     * Return headers for api request
+     */
+    private static function getHeaders()
+    {
+        return array(
+            'cache-control: no-cache',
+            'content-type: application/json',
+            'x-access-token: ' . Configuration::get(MobbexHelper::K_ACCESS_TOKEN),
+            'x-api-key: ' . Configuration::get(MobbexHelper::K_API_KEY),
+        );
+    }
+
+    /**
+     * Process the data string of mobbex_transaction table 
+     * and return the transaction_id of mobbex transaction
+     */
+    private function processOrderData($data){
+        $transactio_id = '';
+        if(strlen($data) > 0){
+            $result = strstr($data,'"id":');
+            $result2 = strstr($result,',',true);
+            $arrayNo= array('"','id:');//strings we need to cut
+            $transactio_id = str_replace($arrayNo, "", $result2);
+        }
+        return $transactio_id;
     }
 
     /**


### PR DESCRIPTION
# Description

When an order state is set to "refund", its trigger a hook that notify Mobbex (using the transaction id) about the total refund.


## Tasks

- [x] Add the new hook in Order page
- [x] Send the order refund information to Mobbex

# Tested

The plugin was tested in the following versions of Prestashop
- [x] 1.6