### PR TITLE
Change configuration methods  and Delete added states used on  plugin installation

### DIFF
--- a/mobbex/mobbex.php
+++ b/mobbex/mobbex.php
@@ -50,7 +50,14 @@ class Mobbex extends PaymentModule
 
         // On 1.7.5 ignores the creation and finishes on an Fatal Error
         // Create the States if not exists because are really important
-        $this->_createStates();
+        $modules = PaymentModuleCore::getInstalledPaymentModules();
+        foreach ($modules as $module) {
+            // Check if the module is installed
+            if ($module['name'] === $this->name) {
+                $this->_createStates();
+                break;
+            }
+        }
 
         // Only if you want to publish your module on the Addons Marketplace
         $this->module_key = 'mobbex_checkout';
@@ -123,11 +130,11 @@ class Mobbex extends PaymentModule
         $id_waiting = Configuration::get(MobbexHelper::K_OS_WAITING);
         $order_state_waiting = new OrderState($id_waiting);
         $order_state_waiting->delete();
-        
+
         $id_rejected = Configuration::get(MobbexHelper::K_OS_REJECTED);
         $order_state_rejected = new OrderState($id_rejected);
         $order_state_rejected->delete();
-        
+
         $form_values = $this->getConfigFormValues();
         foreach (array_keys($form_values) as $key) {
             Configuration::deleteByName($key);
@@ -136,15 +143,7 @@ class Mobbex extends PaymentModule
         DB::getInstance()->execute(
             "DROP TABLE IF EXISTS`" . _DB_PREFIX_ . "mobbex_custom_fields`"
         );
-        
-        /**
-         * Deletes all MOBBEX new states duplicated
-         * in the plugin install
-         */
-        DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Pending';");
-        DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Waiting';");
-        DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Rejected Payment';");
-        
+
         return parent::uninstall();
     }
 

--- a/mobbex/mobbex.php
+++ b/mobbex/mobbex.php
@@ -122,7 +122,7 @@ class Mobbex extends PaymentModule
         }
 
         DB::getInstance()->execute(
-            "DROP TABLE `" . _DB_PREFIX_ . "mobbex_custom_fields`"
+            "DROP TABLE IF EXISTS`" . _DB_PREFIX_ . "mobbex_custom_fields`"
         );
         
         $this->_deleteConfigurationStates();

--- a/mobbex/mobbex.php
+++ b/mobbex/mobbex.php
@@ -121,21 +121,30 @@ class Mobbex extends PaymentModule
             Configuration::deleteByName($key);
         }
 
-        $pendingOrderState = new OrderState((int) Configuration::get(MobbexHelper::K_OS_PENDING));
-        $pendingOrderState->delete();
-
-        $waitingOrderState = new OrderState((int) Configuration::get(MobbexHelper::K_OS_WAITING));
-        $waitingOrderState->delete();
-
-        $rejectedOrderState = new OrderState((int) Configuration::get(MobbexHelper::K_OS_REJECTED));
-        $rejectedOrderState->delete();
-
         DB::getInstance()->execute(
-            "DROP TABLE IF EXISTS `" . _DB_PREFIX_ . "mobbex_custom_fields`"
+            "DROP TABLE `" . _DB_PREFIX_ . "mobbex_custom_fields`"
         );
-
+        
+        $this->_deleteConfigurationStates();
+        
         return parent::uninstall();
     }
+
+    /**
+     * Deletes all MOBBEX configurations and the new states added 
+     * in the plugin install
+     */
+    private function _deleteConfigurationStates()
+    {
+        Configuration::deleteByName(MobbexHelper::K_OS_PENDING);
+        Configuration::deleteByName(MobbexHelper::K_OS_WAITING);
+        Configuration::deleteByName(MobbexHelper::K_OS_REJECTED);
+        DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Pending';");
+        DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Waiting';");
+        DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Rejected Payment';");
+        
+    }
+    
 
     /**
      * Entry point to the module configuration page
@@ -489,8 +498,9 @@ class Mobbex extends PaymentModule
 
     private function _createStates()
     {
+        
         // Pending Status
-        if (!Configuration::get(MobbexHelper::K_OS_PENDING)) {
+        if (!Configuration::hasKey(MobbexHelper::K_OS_PENDING)) {
             $order_state = new OrderState();
             $order_state->name = array();
 
@@ -515,7 +525,7 @@ class Mobbex extends PaymentModule
         }
 
         // Waiting Status
-        if (!Configuration::get(MobbexHelper::K_OS_WAITING)) {
+        if (!Configuration::hasKey(MobbexHelper::K_OS_WAITING)) {
             $order_state = new OrderState();
             $order_state->name = array();
 
@@ -540,7 +550,7 @@ class Mobbex extends PaymentModule
         }
 
         // Rejected Status
-        if (!Configuration::get(MobbexHelper::K_OS_REJECTED)) {
+        if (!Configuration::hasKey(MobbexHelper::K_OS_REJECTED)) {
             $order_state = new OrderState();
             $order_state->name = array();
 

--- a/mobbex/mobbex.php
+++ b/mobbex/mobbex.php
@@ -116,6 +116,18 @@ class Mobbex extends PaymentModule
      */
     public function uninstall()
     {
+        $id_pending = Configuration::get(MobbexHelper::K_OS_PENDING);
+        $order_state_pending = new OrderState($id_pending);
+        $order_state_pending->delete();
+
+        $id_waiting = Configuration::get(MobbexHelper::K_OS_WAITING);
+        $order_state_waiting = new OrderState($id_waiting);
+        $order_state_waiting->delete();
+        
+        $id_rejected = Configuration::get(MobbexHelper::K_OS_REJECTED);
+        $order_state_rejected = new OrderState($id_rejected);
+        $order_state_rejected->delete();
+        
         $form_values = $this->getConfigFormValues();
         foreach (array_keys($form_values) as $key) {
             Configuration::deleteByName($key);
@@ -125,25 +137,18 @@ class Mobbex extends PaymentModule
             "DROP TABLE IF EXISTS`" . _DB_PREFIX_ . "mobbex_custom_fields`"
         );
         
-        $this->_deleteConfigurationStates();
-        
-        return parent::uninstall();
-    }
-
-    /**
-     * Deletes all MOBBEX configurations and the new states added 
-     * in the plugin install
-     */
-    private function _deleteConfigurationStates()
-    {
-        Configuration::deleteByName(MobbexHelper::K_OS_PENDING);
-        Configuration::deleteByName(MobbexHelper::K_OS_WAITING);
-        Configuration::deleteByName(MobbexHelper::K_OS_REJECTED);
+        /**
+         * Deletes all MOBBEX new states duplicated
+         * in the plugin install
+         */
         DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Pending';");
         DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Waiting';");
         DB::getInstance()->execute("DELETE FROM `" . _DB_PREFIX_ . "order_state_lang` WHERE name='Rejected Payment';");
         
+        return parent::uninstall();
     }
+
+    
     
 
     /**


### PR DESCRIPTION
# Description

Fix  installation problems, like duplicated states and Mobbex configuration.

## Changes Added

- [x] Configuration:get() was not working, so it's change to  hasKey().
- [x] Method delete() not working changed for Configuration::DeleteByName().
- [x] Delete added states on uninstall.
