### PR TITLE
[SUGASUP-1071] Fix zero paid amount on webhook order creation

### DIFF
--- a/mobbex/Models/OrderHelper.php
+++ b/mobbex/Models/OrderHelper.php
@@ -55,6 +55,13 @@ class OrderHelper
 
         $amountPaid = $this->getRoundedTotal($cart);
 
+        // A cart resolving to zero means a broken context, not a free order
+        if (!$amountPaid)
+            return Logger::log($die ? 'fatal' : 'error', 'Helper > createOrder | [Order Creation Aborted] Cart total resolved to zero', [
+                'cart_id'      => $cartId,
+                'order_status' => $orderStatus,
+            ]);
+
         try {
             $db = \Db::getInstance();
 

--- a/mobbex/Models/OrderHelper.php
+++ b/mobbex/Models/OrderHelper.php
@@ -39,7 +39,7 @@ class OrderHelper
     /**
      * Create an order from Cart.
      * 
-     * @param int|string $cartId
+     * @param \Cart|int|string $cart
      * @param int|string $orderStatus
      * @param string $methodName
      * @param \PaymentModuleCore $module
@@ -47,17 +47,22 @@ class OrderHelper
      * 
      * @return \Order|null
      */
-    public function createOrder($cartId, $orderStatus, $methodName, $module, $die = true)
+    public function createOrder($cart, $orderStatus, $methodName, $module, $die = true)
     {
+        // Reuse the caller Cart instance: rebuilding it here loses cart rules applied moments before
+        $cart   = is_object($cart) ? $cart : new \Cart($cart);
+        $cartId = $cart->id;
+
+        $amountPaid = $this->getRoundedTotal($cart);
+
         try {
-            $db   = \Db::getInstance();
-            $cart = new \Cart($cartId);
+            $db = \Db::getInstance();
 
             // Validate order, remember to send secure key to avoid warning logs
             $module->validateOrder(
                 $cartId,
                 $orderStatus,
-                $this->getRoundedTotal($cart),
+                $amountPaid,
                 $methodName,
                 null,
                 [],
@@ -577,6 +582,21 @@ class OrderHelper
 
         // Instance context to get computing precision
         $context = \Context::getContext();
+
+        // Webhooks run with no session. Without a customer in context Group::getCurrent() falls back to the
+        // unidentified group, changing the tax method and group prices, so the cart can total zero.
+        // Rebuild it the same way PaymentModule::validateOrder does before computing.
+        if (!\Validate::isLoadedObject($context->customer) || $context->customer->id != $cart->id_customer) {
+            $context->cart     = $cart;
+            $context->customer = new \Customer((int) $cart->id_customer);
+            $context->shop     = new \Shop((int) $cart->id_shop);
+            $context->currency = new \Currency((int) $cart->id_currency, null, (int) $cart->id_shop);
+
+            $cart->setTaxCalculationMethod();
+            \Cart::resetStaticCache();
+            // Drop product prices already cached under the previous group
+            $cart->getProducts(true);
+        }
 
         return (float) \Tools::ps_round(
             (float) $cart->getOrderTotal(),

--- a/mobbex/Models/OrderUpdate.php
+++ b/mobbex/Models/OrderUpdate.php
@@ -43,9 +43,8 @@ class OrderUpdate
             $payment->card_holder     = isset($cardHolder['name']) ? $cardHolder['name'] : null;
             $payment->card_brand      = $data['source_type'];
 
-            // If is new payment, update order real paid
-            if (!isset($payments[0]))
-                $order->total_paid_real = $order->total_paid;
+            // Always refresh it: the payment row may already exist holding a wrong amount
+            $order->total_paid_real = $order->total_paid;
 
             return $payment->save() && $order->update();
         } catch (\Exception $e) {

--- a/mobbex/Models/OrderUpdate.php
+++ b/mobbex/Models/OrderUpdate.php
@@ -21,6 +21,13 @@ class OrderUpdate
             if (!$payment || \Mobbex\PS\Checkout\Models\Transaction::getState($data['status_code']) != 'approved')
                 return;
 
+            // Never overwrite the payment with a zero amount
+            if (!(float) $data['total'])
+                return Logger::log('error', 'OrderUpdate > updateOrderPayment | Approved webhook with zero total, payment left untouched', [
+                    'order_id' => $order->id,
+                    'total'    => $data['total'],
+                ]);
+
             // First, decode jsons to use data safely
             $sourceExpiration = json_decode($data['source_expiration'], true); // chemes
             $cardHolder       = json_decode($data['cardholder'], true);

--- a/mobbex/controllers/front/notification.php
+++ b/mobbex/controllers/front/notification.php
@@ -240,7 +240,7 @@ class MobbexNotificationModuleFrontController extends ModuleFrontController
             $cartRule = $this->orderUpdate->updateCartTotal($cart->id, $trx->total);
 
         // Create and validate Order
-        $order = $this->module->helper->createOrder($cart->id, $data['order_status'], $trx->source_name, $this->module, false);
+        $order = $this->module->helper->createOrder($cart, $data['order_status'], $trx->source_name, $this->module, false);
 
         if ($order)
             $this->orderUpdate->updateOrderPayment($order, $data);

--- a/mobbex/controllers/front/notification.php
+++ b/mobbex/controllers/front/notification.php
@@ -235,6 +235,14 @@ class MobbexNotificationModuleFrontController extends ModuleFrontController
             );
         }
 
+        // Exit if the webhook carries no amount: an approved payment always has a total
+        if (!(float) $trx->total)
+            return Logger::log('error', 'notification > createOrder | [Order Creation Aborted] Webhook with zero total', [
+                'cart'        => $cart->id,
+                'transaction' => $trx->id,
+                'total'       => $trx->total,
+            ]);
+
         // If finance charge discuount is enable, update cart total
         if (Config::$settings['charge_discount'])
             $cartRule = $this->orderUpdate->updateCartTotal($cart->id, $trx->total);


### PR DESCRIPTION
Cuando entraba un webhook podía, en algunas ocaciones, perderse el contexto de la sesión (no el carrito en sí, sino el `Context` entero). Entonces intentamos crear el pedido, y Presta lo crea con status PS_ERROR, pero nosotros no lo notamos porque justo después de crearlo actualizamos el status a Processing. El `total_paid_real` quedaba en cero, mientras que el `total_paid` que seteaba PrestaShop (regenerando el contexto) quedaba con el monto correcto.

El fix pasa por regenerar el contexto de la misma forma que lo hace PrestaShop. También sumo los siguientes cambios en esta PR:
- En cada recepción de webhook aprobado se refresca el `total_paid_real` mediante el `total_paid`.
- Nuevas clausulas de guarda y logs para prevenir totales malformados.